### PR TITLE
Remove snapshot from dockerunit current version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.github.dockerunit</groupId>
     <artifactId>dockerunit-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
This PR needs the version of the parent pom released first :) 
