### PR TITLE
fix: Use the 'reference' filter for GET /images/json

### DIFF
--- a/src/main/java/com/github/dockerunit/core/internal/docker/DefaultDockerClientProvider.java
+++ b/src/main/java/com/github/dockerunit/core/internal/docker/DefaultDockerClientProvider.java
@@ -15,6 +15,7 @@ public class DefaultDockerClientProvider implements DockerClientProvider {
         String dockerServerUrl = System.getProperty(DOCKER_SERVER_URL, DOCKER_SOCKET);
         DockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder()
                 .withDockerHost(dockerServerUrl)
+                .withApiVersion("1.40")
                 .build();
         client = DockerClientBuilder.getInstance(config).build();
     }


### PR DESCRIPTION
- This drops support for Docker below or at v1.13